### PR TITLE
fix: Fix `install-required-terraform-version` command to use 0.13 terraform version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
       - general/publish-circleci-dev:
           context: Orb Publishing
           orb-ref: zeitler/general
-          token-variable: $ORB_PUBLISHING_TOKEN
+          token-variable: ORB_PUBLISHING_TOKEN
           requires:
             - general/lint-commit
             - general/lint-json
@@ -53,7 +53,7 @@ workflows:
           git-user-email: 18561582+bzeitler69@users.noreply.github.com
           git-user-name: "Release Bot"
           orb-ref: zeitler/general
-          token-variable: $ORB_PUBLISHING_TOKEN
+          token-variable: ORB_PUBLISHING_TOKEN
           requires:
             - general/lint-commit
             - general/lint-json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-  circleci-cli: circleci/circleci-cli@0.1.1
-  orbs: circleci/orb-tools@2.0.2
-  general: edahlseng/general@1.24.0
+  circleci-cli: circleci/circleci-cli@0.1.8
+  orbs: circleci/orb-tools@10.0.0
+  general: zeitler/general@0.0.2
 
 workflows:
   main:
@@ -23,7 +23,7 @@ workflows:
             - general/install-dependencies-npm
       - general/publish-circleci-dev:
           context: Orb Publishing
-          orb-ref: edahlseng/general
+          orb-ref: zeitler/general
           token-variable: $ORB_PUBLISHING_TOKEN
           requires:
             - general/lint-commit
@@ -35,8 +35,8 @@ workflows:
               ignore: master
       - general/create-release-pr:
           context: Release Bot
-          git-ssh-fingerprint: da:75:0b:32:cf:ea:fe:8f:c6:0e:6a:82:6c:fb:c4:78
-          git-user-email: edahlseng@users.noreply.github.com
+          git-ssh-fingerprint: d6:86:49:e8:0c:7d:11:a0:ff:3e:ac:75:b0:15:8d:d8
+          git-user-email: 18561582+bzeitler69@users.noreply.github.com
           git-user-name: "Release Bot"
           github-access-token: $RELEASE_BOT_GITHUB_TOKEN
           requires:
@@ -49,10 +49,10 @@ workflows:
               only: master
       - general/tag-and-publish-circleci:
           context: Orb Publishing
-          git-ssh-fingerprint: da:75:0b:32:cf:ea:fe:8f:c6:0e:6a:82:6c:fb:c4:78
-          git-user-email: edahlseng@users.noreply.github.com
+          git-ssh-fingerprint: d6:86:49:e8:0c:7d:11:a0:ff:3e:ac:75:b0:15:8d:d8
+          git-user-email: 18561582+bzeitler69@users.noreply.github.com
           git-user-name: "Release Bot"
-          orb-ref: edahlseng/general
+          orb-ref: zeitler/general
           token-variable: $ORB_PUBLISHING_TOKEN
           requires:
             - general/lint-commit

--- a/sources/index.yml
+++ b/sources/index.yml
@@ -3,13 +3,13 @@ version: 2.1
 description: General purpose continuous integration configuration
 
 orbs:
-  circleci-cli: circleci/circleci-cli@0.1.1
-  orbs: circleci/orb-tools@2.0.2
+  circleci-cli: circleci/circleci-cli@0.1.8
+  orbs: circleci/orb-tools@10.0.0
 
 executors:
   node:
     docker:
-      - image: circleci/node:10.16.3-buster
+      - image: circleci/node:10.22-buster
         user: circleci
   buildpack-deps:
     docker:
@@ -407,7 +407,7 @@ commands:
           name: Installing required Terraform version
           command: |
             cd << parameters.directory >>
-            desiredTerraformVersion=$(cat main.tf | grep --extended-regexp '^\s*required_version\s*=\s*"\s*(=|>=)?\s*[0-9]+\.[0-9]+\.[0-9]+\s*"\s*$' | head | sed -E 's/^.*([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
+            desiredTerraformVersion=$(cat versions.tf | grep --extended-regexp '^\s*required_version\s*=\s*"\s*(=|>=)?\s*[0-9]+\.[0-9]+\.[0-9]+\s*"\s*$' | head | sed -E 's/^.*([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
             tfenv install "${desiredTerraformVersion}" && tfenv use "${desiredTerraformVersion}"
   install-terraform-version:
     parameters:

--- a/sources/index.yml
+++ b/sources/index.yml
@@ -947,7 +947,7 @@ jobs:
         description: A versionless orb-ref in the form <namespace>/<orb-name>
         type: string
       token-variable:
-        description: The env var containing your token. Pass this as a literal string such as `${ORB_PUBLISHING_TOKEN}`. Do not paste the actual token into your configuration.
+        description: Name of env var containing your token. Pass this as a raw string such as ORB_PUBLISHING_TOKEN. Do not paste the actual token into your configuration.
         type: string
     steps:
       - get-workspace
@@ -985,7 +985,7 @@ jobs:
         description: A versionless orb-ref in the form <namespace>/<orb-name>
         type: string
       token-variable:
-        description: The env var containing your token. Pass this as a literal string such as `${ORB_PUBLISHING_TOKEN}`. Do not paste the actual token into your configuration.
+        description: Name of env var containing your token. Pass this as a raw string such as ORB_PUBLISHING_TOKEN. Do not paste the actual token into your configuration.
         type: string
     steps:
       - get-workspace


### PR DESCRIPTION
### Description
- Fixed `install-required-terraform-version` command to use 0.13 terraform version
- Updated CircleCI config

### Notes
Orb [link](https://circleci.com/orbs/registry/orb/zeitler/general?version=0.0.2)